### PR TITLE
Add initial Flask application

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,22 @@
-this is task1
+# Patient Task Tracker
+
+This project is a simple Flask-based application for tracking patient-related tasks. It demonstrates the following features:
+
+- **Login System** with user roles (admin or regular).
+- **Deadline Tracking** with color indicators (green for >7 days, yellow for <=7, red if overdue).
+- **Task Update Logging** to record who completed a task and when.
+- Basic HTML templates for listing and completing tasks.
+
+To initialize the database, run the following commands:
+
+```bash
+python -c "from app import db; db.create_all()"
+```
+
+Run the development server:
+
+```bash
+flask run
+```
+
+Dependencies are listed in `requirements.txt`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,79 @@
+from datetime import datetime, timedelta
+from flask import Flask, render_template, request, redirect, url_for, session
+from flask_sqlalchemy import SQLAlchemy
+from werkzeug.security import generate_password_hash, check_password_hash
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'change_this'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///patient_tasks.db'
+db = SQLAlchemy(app)
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(20), default='regular')
+
+class Patient(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), nullable=False)
+
+class Task(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    patient_id = db.Column(db.Integer, db.ForeignKey('patient.id'), nullable=False)
+    description = db.Column(db.String(200), nullable=False)
+    due_date = db.Column(db.Date, nullable=False)
+    completed = db.Column(db.Boolean, default=False)
+    patient = db.relationship('Patient', backref=db.backref('tasks', lazy=True))
+
+class TaskLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    task_id = db.Column(db.Integer, db.ForeignKey('task.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    comment = db.Column(db.String(200))
+    task = db.relationship('Task', backref=db.backref('logs', lazy=True))
+    user = db.relationship('User')
+
+def color_for_deadline(due_date):
+    today = datetime.utcnow().date()
+    if due_date < today:
+        return 'red'
+    elif due_date - today <= timedelta(days=7):
+        return 'yellow'
+    return 'green'
+
+@app.route('/')
+def index():
+    if 'user_id' not in session:
+        return redirect(url_for('login'))
+    tasks = Task.query.all()
+    return render_template('index.html', tasks=tasks, color_for_deadline=color_for_deadline)
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        user = User.query.filter_by(username=request.form['username']).first()
+        if user and check_password_hash(user.password_hash, request.form['password']):
+            session['user_id'] = user.id
+            return redirect(url_for('index'))
+    return render_template('login.html')
+
+@app.route('/logout')
+def logout():
+    session.pop('user_id', None)
+    return redirect(url_for('login'))
+
+@app.route('/complete/<int:task_id>', methods=['POST'])
+def complete(task_id):
+    if 'user_id' not in session:
+        return redirect(url_for('login'))
+    task = Task.query.get_or_404(task_id)
+    task.completed = True
+    log = TaskLog(task=task, user_id=session['user_id'], comment='completed')
+    db.session.add(log)
+    db.session.commit()
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask_SQLAlchemy
+Werkzeug

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head><title>Tasks</title></head>
+<body>
+  <h1>Task List</h1>
+  <table border="1">
+    <tr><th>Patient</th><th>Description</th><th>Due Date</th><th>Status</th><th>Action</th></tr>
+    {% for task in tasks %}
+    <tr style="background-color: {{ color_for_deadline(task.due_date) }};">
+      <td>{{ task.patient.name }}</td>
+      <td>{{ task.description }}</td>
+      <td>{{ task.due_date }}</td>
+      <td>{{ 'Done' if task.completed else 'Pending' }}</td>
+      <td>
+        {% if not task.completed %}
+        <form action="{{ url_for('complete', task_id=task.id) }}" method="post">
+          <button type="submit">Complete</button>
+        </form>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </table>
+  <a href="{{ url_for('logout') }}">Logout</a>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head><title>Login</title></head>
+<body>
+  <h1>Login</h1>
+  <form method="post">
+    <input name="username" placeholder="Username" required>
+    <input name="password" type="password" placeholder="Password" required>
+    <button type="submit">Login</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create minimal Flask app with login and task views
- track tasks, patients, and logs with SQLAlchemy
- show color-coded deadline status and allow task completion
- document setup instructions

## Testing
- `python -m py_compile app.py`
- `python -m flask --version` *(fails: No module named flask)*
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_684b3154886c832cbd795017b4cd9fad